### PR TITLE
feat: reproducible builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,22 @@
-FROM alpine:3.15.4
+FROM docker.io/library/golang:alpine3.17 AS build
 
-RUN apk update
-RUN apk add curl bash tzdata
+WORKDIR /workspace
+ADD . /workspace
 
-COPY bin/linux/private-ghp /app/private-ghp
+RUN apk update && \
+    apk add git make
+
+RUN make build
+
+FROM docker.io/library/alpine:3.17
+
+RUN apk update && \
+    apk add curl bash tzdata
+
+COPY --from=build /workspace/bin/generic/private-ghp /app/private-ghp
 RUN chmod u+x /app/private-ghp
 
+ENV TZ=UTC
 COPY entrypoint.sh /app/entrypoint.sh
 RUN chmod u+x /app/entrypoint.sh
 

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,22 @@
+CONTAINER_RUNTIME=$(shell which docker)
+
 prepare:
 	go mod tidy
 
 run:
 	go run -race main.go handler.go github.go
 
+build:
+	mkdir -p bin/generic
+	go build -o bin/generic/private-ghp main.go handler.go github.go
+
 build+darwin:
 	mkdir -p bin/darwin
-	GOOS=darwin GOARCH=amd64 go build  -o bin/darwin/private-ghp main.go handler.go github.go
+	GOOS=darwin GOARCH=amd64 go build -o bin/darwin/private-ghp main.go handler.go github.go
 
 build+linux:
 	mkdir -p bin/linux
-	GOOS=linux GOARCH=amd64 go build  -o bin/linux/private-ghp main.go handler.go github.go
+	GOOS=linux GOARCH=amd64 go build -o bin/linux/private-ghp main.go handler.go github.go
 
-build+docker: build+linux
-	docker build -t private-ghp:latest .
+build+docker:
+	${CONTAINER_RUNTIME} build -t private-ghp:latest .

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
 
-echo $TZ > /etc/timezone 
+# NOTE: Environment variable TZ is pre-defined in Dockerfile and ca be
+# customized via docker run --env or docker-compose.
+echo ${TZ} > /etc/timezone
+
 /app/private-ghp


### PR DESCRIPTION
The following patch include some changed of the Makefile and Dockerfile to guarantee reproducible builds.

Use fully qualified container image registry
- Not all users use as default docker.io.

Container runtime can be customized:
- Not all users use docker as default container runtime.

Introduce build stage in Dockerfile
- The build environment on the user side does not have the project in hand. For this reason, build+linux was probably also specified as a dependency in the Makefile. This has now been resolved. The program is now built in a separate build stage and copied to the target container image. This guarantees a uniform build environment.